### PR TITLE
Feat: Add ability to show/hide Null Values

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,3 +116,4 @@ app.*.symbols
 !**/ios/**/default.perspectivev3
 !/packages/flutter_tools/test/data/dart_dependencies_test/**/.packages
 !/dev/ci/**/Gemfile.lock
+classes.code-search

--- a/lib/questionnaires/view/item/answer/src/coding_answer_filler.dart
+++ b/lib/questionnaires/view/item/answer/src/coding_answer_filler.dart
@@ -58,15 +58,19 @@ class _CodingAnswerState extends QuestionnaireAnswerFillerState<CodeableConcept,
 
     final choices = <Widget>[];
     if (!isMultipleChoice) {
-      choices.add(RadioListTile<String?>(
-          title: const NullDashText(),
-          value: null,
-          groupValue: answerModel.toChoiceString(value),
-          onChanged: (answerModel.isEnabled)
-              ? (String? newValue) {
-                  value = answerModel.fromChoiceString(newValue);
-                }
-              : null));
+      if (QuestionnaireFiller.of(context).showNullCodingOption) {
+        choices.add(
+          RadioListTile<String?>(
+              title: const NullDashText(),
+              value: null,
+              groupValue: answerModel.toChoiceString(value),
+              onChanged: (answerModel.isEnabled)
+                  ? (String? newValue) {
+                      value = answerModel.fromChoiceString(newValue);
+                    }
+                  : null),
+        );
+      }
     }
     for (final choice in answerModel.answerOptions.values) {
       final optionPrefix = choice.extension_
@@ -130,6 +134,8 @@ class _CodingAnswerState extends QuestionnaireAnswerFillerState<CodeableConcept,
                 child: RadioListTile<String>(
                     title: styledOptionTitle,
                     value: choice.optionCode,
+                    // allows value to be set to null on repeat tap
+                    toggleable: true,
                     groupValue: answerModel.toChoiceString(value),
                     onChanged: (answerModel.isEnabled)
                         ? (String? newValue) {

--- a/lib/questionnaires/view/item/answer/src/coding_answer_filler.dart
+++ b/lib/questionnaires/view/item/answer/src/coding_answer_filler.dart
@@ -55,10 +55,11 @@ class _CodingAnswerState extends QuestionnaireAnswerFillerState<CodeableConcept,
   Widget _buildChoiceAnswers(BuildContext context) {
     final isCheckBox = qi.isItemControl('check-box');
     final isMultipleChoice = (qi.repeats?.value ?? isCheckBox) == true;
+    final isShowingNull = questionnaireTheme.showNullCodingOption();
 
     final choices = <Widget>[];
     if (!isMultipleChoice) {
-      if (QuestionnaireFiller.of(context).showNullCodingOption) {
+      if (isShowingNull) {
         choices.add(
           RadioListTile<String?>(
               title: const NullDashText(),

--- a/lib/questionnaires/view/src/questionnaire_filler.dart
+++ b/lib/questionnaires/view/src/questionnaire_filler.dart
@@ -20,7 +20,6 @@ class QuestionnaireFiller extends StatefulWidget {
   final void Function(BuildContext context, Uri url)? onLinkTap;
   final void Function(QuestionnaireModel)? onDataAvailable;
   final QuestionnaireTheme questionnaireTheme;
-  final bool showNullCodingOption;
 
   final FhirResourceProvider fhirResourceProvider;
 
@@ -30,17 +29,17 @@ class QuestionnaireFiller extends StatefulWidget {
           aggregators: aggregators,
           fhirResourceProvider: fhirResourceProvider);
 
-  const QuestionnaireFiller(
-      {Key? key,
-      required this.locale,
-      required this.builder,
-      required this.fhirResourceProvider,
-      this.aggregators,
-      this.onDataAvailable,
-      this.onLinkTap,
-      this.questionnaireTheme = const FDashQuestionnaireTheme(),
-      bool? showNullCodingOption})
-      : showNullCodingOption = showNullCodingOption ?? true,
+  const QuestionnaireFiller({
+    Key? key,
+    required this.locale,
+    required this.builder,
+    required this.fhirResourceProvider,
+    this.aggregators,
+    this.onDataAvailable,
+    this.onLinkTap,
+    QuestionnaireTheme? questionnaireTheme,
+  })  : questionnaireTheme =
+            questionnaireTheme ?? const FDashQuestionnaireTheme(),
         super(key: key);
 
   static QuestionnaireFillerData of(BuildContext context) {
@@ -127,7 +126,6 @@ class _QuestionnaireFillerState extends State<QuestionnaireFiller> {
                     onLinkTap: widget.onLinkTap,
                     onDataAvailable: widget.onDataAvailable,
                     questionnaireTheme: widget.questionnaireTheme,
-                    showNullCodingOption: widget.showNullCodingOption,
                   );
                 }
                 return _questionnaireFillerData;
@@ -153,17 +151,16 @@ class QuestionnaireFillerData extends InheritedWidget {
   late final List<QuestionnaireItemFiller?> _itemFillers;
   final Map<int, QuestionnaireItemFillerState> _itemFillerStates = {};
   late final int _generation;
-  final bool showNullCodingOption;
 
-  QuestionnaireFillerData._(this.questionnaireModel,
-      {Key? key,
-      required this.locale,
-      this.onDataAvailable,
-      this.onLinkTap,
-      required this.questionnaireTheme,
-      required WidgetBuilder builder,
-      required this.showNullCodingOption})
-      : _generation = questionnaireModel.generation,
+  QuestionnaireFillerData._(
+    this.questionnaireModel, {
+    Key? key,
+    required this.locale,
+    this.onDataAvailable,
+    this.onLinkTap,
+    required this.questionnaireTheme,
+    required WidgetBuilder builder,
+  })  : _generation = questionnaireModel.generation,
         questionnaireItemModels =
             questionnaireModel.orderedQuestionnaireItemModels(),
         _itemFillers = List<QuestionnaireItemFiller?>.filled(

--- a/lib/questionnaires/view/src/questionnaire_filler.dart
+++ b/lib/questionnaires/view/src/questionnaire_filler.dart
@@ -20,6 +20,7 @@ class QuestionnaireFiller extends StatefulWidget {
   final void Function(BuildContext context, Uri url)? onLinkTap;
   final void Function(QuestionnaireModel)? onDataAvailable;
   final QuestionnaireTheme questionnaireTheme;
+  final bool showNullCodingOption;
 
   final FhirResourceProvider fhirResourceProvider;
 
@@ -37,8 +38,10 @@ class QuestionnaireFiller extends StatefulWidget {
       this.aggregators,
       this.onDataAvailable,
       this.onLinkTap,
-      this.questionnaireTheme = const FDashQuestionnaireTheme()})
-      : super(key: key);
+      this.questionnaireTheme = const FDashQuestionnaireTheme(),
+      bool? showNullCodingOption})
+      : showNullCodingOption = showNullCodingOption ?? true,
+        super(key: key);
 
   static QuestionnaireFillerData of(BuildContext context) {
     final result =
@@ -118,12 +121,14 @@ class _QuestionnaireFillerState extends State<QuestionnaireFiller> {
                       _onQuestionnaireModelChangeListenerFunction!);
 
                   _questionnaireFillerData = QuestionnaireFillerData._(
-                      _questionnaireModel!,
-                      locale: widget.locale,
-                      builder: widget.builder,
-                      onLinkTap: widget.onLinkTap,
-                      onDataAvailable: widget.onDataAvailable,
-                      questionnaireTheme: widget.questionnaireTheme);
+                    _questionnaireModel!,
+                    locale: widget.locale,
+                    builder: widget.builder,
+                    onLinkTap: widget.onLinkTap,
+                    onDataAvailable: widget.onDataAvailable,
+                    questionnaireTheme: widget.questionnaireTheme,
+                    showNullCodingOption: widget.showNullCodingOption,
+                  );
                 }
                 return _questionnaireFillerData;
               }
@@ -148,16 +153,17 @@ class QuestionnaireFillerData extends InheritedWidget {
   late final List<QuestionnaireItemFiller?> _itemFillers;
   final Map<int, QuestionnaireItemFillerState> _itemFillerStates = {};
   late final int _generation;
+  final bool showNullCodingOption;
 
-  QuestionnaireFillerData._(
-    this.questionnaireModel, {
-    Key? key,
-    required this.locale,
-    this.onDataAvailable,
-    this.onLinkTap,
-    required this.questionnaireTheme,
-    required WidgetBuilder builder,
-  })  : _generation = questionnaireModel.generation,
+  QuestionnaireFillerData._(this.questionnaireModel,
+      {Key? key,
+      required this.locale,
+      this.onDataAvailable,
+      this.onLinkTap,
+      required this.questionnaireTheme,
+      required WidgetBuilder builder,
+      required this.showNullCodingOption})
+      : _generation = questionnaireModel.generation,
         questionnaireItemModels =
             questionnaireModel.orderedQuestionnaireItemModels(),
         _itemFillers = List<QuestionnaireItemFiller?>.filled(

--- a/lib/questionnaires/view/src/questionnaire_scroller.dart
+++ b/lib/questionnaires/view/src/questionnaire_scroller.dart
@@ -33,7 +33,7 @@ class QuestionnaireScroller extends StatefulWidget {
   final List<Aggregator<dynamic>>? aggregators;
   final void Function(BuildContext context, Uri url)? onLinkTap;
   final QuestionnairePageScaffoldBuilder scaffoldBuilder;
-  final bool showNullCodingOption;
+  final QuestionnaireTheme? questionnaireTheme;
 
   const QuestionnaireScroller(
       {this.locale,
@@ -43,10 +43,9 @@ class QuestionnaireScroller extends StatefulWidget {
       this.backMatter,
       this.aggregators,
       this.onLinkTap,
-      bool? showNullCodingOption,
+      this.questionnaireTheme,
       Key? key})
-      : showNullCodingOption = showNullCodingOption ?? true,
-        super(key: key);
+      : super(key: key);
 
   @override
   State<StatefulWidget> createState() => _QuestionnaireScrollerState();
@@ -149,7 +148,7 @@ class _QuestionnaireScrollerState extends State<QuestionnaireScroller> {
     return QuestionnaireFiller(
       fhirResourceProvider: widget.fhirResourceProvider,
       locale: locale,
-      showNullCodingOption: widget.showNullCodingOption,
+      questionnaireTheme: widget.questionnaireTheme,
       builder: (BuildContext context) {
         _belowFillerContext = context;
         final questionnaireFiller = QuestionnaireFiller.of(context);
@@ -332,7 +331,7 @@ class QuestionnaireScrollerPage extends QuestionnaireScroller {
       ],
       List<Aggregator<dynamic>>? aggregators,
       void Function(BuildContext context, Uri url)? onLinkTap,
-      bool? showNullCodingOption,
+      QuestionnaireTheme? questionnaireTheme,
       Key? key})
       : super(
             locale: locale,
@@ -344,6 +343,6 @@ class QuestionnaireScrollerPage extends QuestionnaireScroller {
             backMatter: backMatter,
             aggregators: aggregators,
             onLinkTap: onLinkTap,
-            showNullCodingOption: showNullCodingOption,
+            questionnaireTheme: questionnaireTheme,
             key: key);
 }

--- a/lib/questionnaires/view/src/questionnaire_scroller.dart
+++ b/lib/questionnaires/view/src/questionnaire_scroller.dart
@@ -33,6 +33,7 @@ class QuestionnaireScroller extends StatefulWidget {
   final List<Aggregator<dynamic>>? aggregators;
   final void Function(BuildContext context, Uri url)? onLinkTap;
   final QuestionnairePageScaffoldBuilder scaffoldBuilder;
+  final bool showNullCodingOption;
 
   const QuestionnaireScroller(
       {this.locale,
@@ -42,8 +43,10 @@ class QuestionnaireScroller extends StatefulWidget {
       this.backMatter,
       this.aggregators,
       this.onLinkTap,
+      bool? showNullCodingOption,
       Key? key})
-      : super(key: key);
+      : showNullCodingOption = showNullCodingOption ?? true,
+        super(key: key);
 
   @override
   State<StatefulWidget> createState() => _QuestionnaireScrollerState();
@@ -146,6 +149,7 @@ class _QuestionnaireScrollerState extends State<QuestionnaireScroller> {
     return QuestionnaireFiller(
       fhirResourceProvider: widget.fhirResourceProvider,
       locale: locale,
+      showNullCodingOption: widget.showNullCodingOption,
       builder: (BuildContext context) {
         _belowFillerContext = context;
         final questionnaireFiller = QuestionnaireFiller.of(context);
@@ -328,6 +332,7 @@ class QuestionnaireScrollerPage extends QuestionnaireScroller {
       ],
       List<Aggregator<dynamic>>? aggregators,
       void Function(BuildContext context, Uri url)? onLinkTap,
+      bool? showNullCodingOption,
       Key? key})
       : super(
             locale: locale,
@@ -339,5 +344,6 @@ class QuestionnaireScrollerPage extends QuestionnaireScroller {
             backMatter: backMatter,
             aggregators: aggregators,
             onLinkTap: onLinkTap,
+            showNullCodingOption: showNullCodingOption,
             key: key);
 }

--- a/lib/questionnaires/view/src/questionnaire_stepper.dart
+++ b/lib/questionnaires/view/src/questionnaire_stepper.dart
@@ -10,16 +10,15 @@ class QuestionnaireStepper extends StatefulWidget {
   final Locale? locale;
   final FhirResourceProvider fhirResourceProvider;
   final QuestionnairePageScaffoldBuilder scaffoldBuilder;
-  final bool showNullCodingOption;
+  final QuestionnaireTheme? questionnaireTheme;
 
   const QuestionnaireStepper(
       {this.locale,
       required this.scaffoldBuilder,
       required this.fhirResourceProvider,
-      bool? showNullCodingOption,
+      this.questionnaireTheme,
       Key? key})
-      : showNullCodingOption = showNullCodingOption ?? true,
-        super(key: key);
+      : super(key: key);
 
   @override
   State<StatefulWidget> createState() => _QuestionnaireStepperState();
@@ -34,7 +33,7 @@ class _QuestionnaireStepperState extends State<QuestionnaireStepperPage> {
     return QuestionnaireFiller(
         locale: widget.locale ?? Localizations.localeOf(context),
         fhirResourceProvider: widget.fhirResourceProvider,
-        showNullCodingOption: widget.showNullCodingOption,
+        questionnaireTheme: widget.questionnaireTheme,
         builder: (BuildContext context) {
           final questionnaireFiller = QuestionnaireFiller.of(context);
           final itemCount = questionnaireFiller.questionnaireItemModels.length;
@@ -100,16 +99,16 @@ class _QuestionnaireStepperState extends State<QuestionnaireStepperPage> {
 }
 
 class QuestionnaireStepperPage extends QuestionnaireStepper {
-  const QuestionnaireStepperPage(
-      {Locale? locale,
-      required FhirResourceProvider fhirResourceProvider,
-      bool? showNullCodingOption,
-      Key? key})
-      : super(
+  const QuestionnaireStepperPage({
+    Locale? locale,
+    required FhirResourceProvider fhirResourceProvider,
+    QuestionnaireTheme? questionnaireTheme,
+    Key? key,
+  }) : super(
             locale: locale,
             scaffoldBuilder: const DefaultQuestionnairePageScaffoldBuilder(),
             fhirResourceProvider: fhirResourceProvider,
-            showNullCodingOption: showNullCodingOption,
+            questionnaireTheme: questionnaireTheme,
             key: key);
 
   @override

--- a/lib/questionnaires/view/src/questionnaire_stepper.dart
+++ b/lib/questionnaires/view/src/questionnaire_stepper.dart
@@ -10,13 +10,16 @@ class QuestionnaireStepper extends StatefulWidget {
   final Locale? locale;
   final FhirResourceProvider fhirResourceProvider;
   final QuestionnairePageScaffoldBuilder scaffoldBuilder;
+  final bool showNullCodingOption;
 
   const QuestionnaireStepper(
       {this.locale,
       required this.scaffoldBuilder,
       required this.fhirResourceProvider,
+      bool? showNullCodingOption,
       Key? key})
-      : super(key: key);
+      : showNullCodingOption = showNullCodingOption ?? true,
+        super(key: key);
 
   @override
   State<StatefulWidget> createState() => _QuestionnaireStepperState();
@@ -31,6 +34,7 @@ class _QuestionnaireStepperState extends State<QuestionnaireStepperPage> {
     return QuestionnaireFiller(
         locale: widget.locale ?? Localizations.localeOf(context),
         fhirResourceProvider: widget.fhirResourceProvider,
+        showNullCodingOption: widget.showNullCodingOption,
         builder: (BuildContext context) {
           final questionnaireFiller = QuestionnaireFiller.of(context);
           final itemCount = questionnaireFiller.questionnaireItemModels.length;
@@ -99,11 +103,13 @@ class QuestionnaireStepperPage extends QuestionnaireStepper {
   const QuestionnaireStepperPage(
       {Locale? locale,
       required FhirResourceProvider fhirResourceProvider,
+      bool? showNullCodingOption,
       Key? key})
       : super(
             locale: locale,
             scaffoldBuilder: const DefaultQuestionnairePageScaffoldBuilder(),
             fhirResourceProvider: fhirResourceProvider,
+            showNullCodingOption: showNullCodingOption,
             key: key);
 
   @override

--- a/lib/questionnaires/view/src/questionnaire_theme.dart
+++ b/lib/questionnaires/view/src/questionnaire_theme.dart
@@ -30,13 +30,27 @@ abstract class QuestionnaireTheme {
 
   /// Returns whether user will be offered option to skip question.
   bool showSkipOption();
+
+  /// Returns whether user will be offered option for a null radio button value.
+  bool showNullCodingOption();
 }
 
 /// The Faiadashu default implementation of [QuestionnaireTheme].
 class FDashQuestionnaireTheme implements QuestionnaireTheme {
   static final _logger = Logger(FDashQuestionnaireTheme);
 
-  const FDashQuestionnaireTheme();
+  /// These options may be set to customize the Faiadashu default theme
+  ///
+  /// To use this, call `questionnaireTheme: FDashQuestionnaireTheme()`
+  /// within [QuestionnaireScroller], [QuestionnaireScrollerPage],
+  /// [QuestionnaireStepper], or [QuestionnaireStepperPage]
+  /// and set the options you want
+
+  final bool? canSkipQuestions;
+  final bool? showNullAnswerChoices;
+
+  const FDashQuestionnaireTheme(
+      {this.canSkipQuestions, this.showNullAnswerChoices});
 
   @override
   QuestionnaireItemFiller createQuestionnaireItemFiller(
@@ -99,5 +113,8 @@ class FDashQuestionnaireTheme implements QuestionnaireTheme {
   }
 
   @override
-  bool showSkipOption() => false;
+  bool showSkipOption() => canSkipQuestions ?? false;
+
+  @override
+  bool showNullCodingOption() => showNullAnswerChoices ?? true;
 }


### PR DESCRIPTION
# Description

This PR allows for the customization of answer options that input a code as a response. Prior to this implementation, all choice options (displayed with radio buttons) would default to show a blank radio button at the top of each answer choice. An image example of this is shown below:

![showNullAnswerChoices-true](https://user-images.githubusercontent.com/45612810/126663978-f828dd45-8012-48d4-94b4-2a8b667a6cca.png)

By setting the named parameter `showNullAnswerChoices` to false...

```dart
QuestionnaireScrollerPage(
              questionnaireTheme: const FDashQuestionnaireTheme(
                showNullAnswerChoices: false,
              ),
              ...
```

All choice / radio button questions have one fewer question, as the null values on top are not shown. This questionnaireTheme variable may be set within `QuestionnaireScrollerPage`, `QuestionnaireScroller`, `QuestionnaireStepperPage`, or `QuestionnaireStepper` classes...depending on UI requirements of your survey.
![showNullAnswerChoices-false](https://user-images.githubusercontent.com/45612810/126664053-4defc17b-cfe5-4568-8803-f2f133a84557.png)


## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update


## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules