### PR TITLE
Show Question Numbers

### DIFF
--- a/lib/questionnaires/model/item/src/response_model.dart
+++ b/lib/questionnaires/model/item/src/response_model.dart
@@ -75,6 +75,7 @@ class ResponseModel {
     _ensureAnswerModel();
 
     final markers = <QuestionnaireErrorFlag>[];
+
     for (final am in _cachedAnswerModels.values) {
       final marker = am.isComplete;
       if (marker != null) {
@@ -91,7 +92,7 @@ class ResponseModel {
     return _cachedAnswerModels.values.any((am) => !am.isUnanswered);
   }
 
-  final _cachedAnswerModels = <int, AnswerModel>{};
+  final Map<int, AnswerModel> _cachedAnswerModels = <int, AnswerModel>{};
 
   /// Returns an [AnswerModel] for the nth answer to an overall response.
   ///

--- a/lib/questionnaires/model/src/questionnaire_item_model.dart
+++ b/lib/questionnaires/model/src/questionnaire_item_model.dart
@@ -185,6 +185,44 @@ class QuestionnaireItemModel extends ChangeNotifier with Diagnosticable {
     }
   }
 
+  /// Returns an integer, starting with 1, that provides the number
+  /// of [QuestionnaireModel]s that have [isAnswerable] flags set to true
+  ///
+  int getQuestionNumber(int answerIndex) {
+    late final int questionNumber;
+
+    /// If [answerIndex] falls within the _cachedAnswerModels data set...
+    /// Check each question in turn until [answerIndex] is reached.
+    /// Create a count of all questions that are labeled as answerable until
+    /// [answerIndexx]
+    ///
+    if (_orderedItems != null) {
+      if (_orderedItems!.length >= answerIndex) {
+        var iterable = 1;
+        for (var idx = 0; idx < answerIndex; idx++) {
+          // Use linked hash map to ensure a key exists at this answer index
+          if (_orderedItems?.keys.elementAt(idx).isNotEmpty ?? false) {
+            // If a key exists, check to see if the isAnswerable flag is true
+            if (_orderedItems?[_orderedItems?.keys.elementAt(idx)]
+                    ?.isAnswerable ??
+                false) {
+              iterable++;
+            }
+          }
+        }
+        questionNumber = iterable;
+      } else {
+        _qimLogger.debug(
+            'error: answerIndex $answerIndex not found in _orderedItems');
+        questionNumber = -1;
+      }
+    } else {
+      _qimLogger.debug('error: _orderedItems not found');
+      questionNumber = -1;
+    }
+    return questionNumber;
+  }
+
   /// Returns the associated [QuestionnaireResponseItem].
   QuestionnaireResponseItem? get responseItem => _questionnaireResponseItem;
 

--- a/lib/questionnaires/model/src/questionnaire_item_model.dart
+++ b/lib/questionnaires/model/src/questionnaire_item_model.dart
@@ -212,12 +212,12 @@ class QuestionnaireItemModel extends ChangeNotifier with Diagnosticable {
         }
         questionNumber = iterable;
       } else {
-        _qimLogger.debug(
+        _qimLogger.error(
             'error: answerIndex $answerIndex not found in _orderedItems');
         questionNumber = -1;
       }
     } else {
-      _qimLogger.debug('error: _orderedItems not found');
+      _qimLogger.error('error: _orderedItems not found');
       questionNumber = -1;
     }
     return questionNumber;

--- a/lib/questionnaires/view/item/answer/src/coding_answer_filler.dart
+++ b/lib/questionnaires/view/item/answer/src/coding_answer_filler.dart
@@ -55,7 +55,7 @@ class _CodingAnswerState extends QuestionnaireAnswerFillerState<CodeableConcept,
   Widget _buildChoiceAnswers(BuildContext context) {
     final isCheckBox = qi.isItemControl('check-box');
     final isMultipleChoice = (qi.repeats?.value ?? isCheckBox) == true;
-    final isShowingNull = questionnaireTheme.showNullCodingOption();
+    final isShowingNull = questionnaireTheme.showNullAnswerChoices ?? true;
 
     final choices = <Widget>[];
     if (!isMultipleChoice) {

--- a/lib/questionnaires/view/item/src/questionnaire_item_filler.dart
+++ b/lib/questionnaires/view/item/src/questionnaire_item_filler.dart
@@ -223,8 +223,8 @@ class QuestionnaireItemFillerTitle extends StatelessWidget {
           TextSpan(
             children: <InlineSpan>[
               /// Show question numbers (if flag set in the Questionnaire Theme)
-              /// items with an index of 0 are skipped, as they usually
-              /// represent basic information about the questionnaire
+              /// All items with the isAnswerable boolean as true will be
+              /// counted, starting with 1, and regardless of grouping.
               ///
               if (questionnaireTheme.showQuestionIndexOption() &&
                   itemModel.isAnswerable)

--- a/lib/questionnaires/view/item/src/questionnaire_item_filler.dart
+++ b/lib/questionnaires/view/item/src/questionnaire_item_filler.dart
@@ -226,8 +226,8 @@ class QuestionnaireItemFillerTitle extends StatelessWidget {
                 WidgetSpan(
                   alignment: PlaceholderAlignment.middle,
                   // baseline: TextBaseline.alphabetic,
-                  child: Text('$index:  ',
-                      style: Theme.of(context).textTheme.headline6),
+                  child: Text('$index: ',
+                      style: Theme.of(context).textTheme.bodyText1),
                 ),
               if (leading != null) WidgetSpan(child: leading!),
               if (itemModel.titleText != null)

--- a/lib/questionnaires/view/item/src/questionnaire_item_filler.dart
+++ b/lib/questionnaires/view/item/src/questionnaire_item_filler.dart
@@ -215,6 +215,7 @@ class QuestionnaireItemFillerTitle extends StatelessWidget {
   Widget build(BuildContext context) {
     final int questionNumber =
         itemModel.questionnaireModel.getQuestionNumber(index);
+    final showQuestionNumbers = questionnaireTheme.showQuestionNumbers ?? false;
 
     return Container(
         alignment: AlignmentDirectional.centerStart,
@@ -226,8 +227,7 @@ class QuestionnaireItemFillerTitle extends StatelessWidget {
               /// All items with the isAnswerable boolean as true will be
               /// counted, starting with 1, and regardless of grouping.
               ///
-              if (questionnaireTheme.showQuestionIndexOption() &&
-                  itemModel.isAnswerable)
+              if (showQuestionNumbers && itemModel.isAnswerable)
                 HTML.toTextSpan(
                   context,
                   '$questionNumber: ',

--- a/lib/questionnaires/view/item/src/questionnaire_item_filler.dart
+++ b/lib/questionnaires/view/item/src/questionnaire_item_filler.dart
@@ -226,7 +226,7 @@ class QuestionnaireItemFillerTitle extends StatelessWidget {
               /// items with an index of 0 are skipped, as they usually
               /// represent basic information about the questionnaire
               ///
-              if (questionnaireTheme.showAnswerIndexOption() &&
+              if (questionnaireTheme.showQuestionIndexOption() &&
                   itemModel.isAnswerable)
                 HTML.toTextSpan(
                   context,

--- a/lib/questionnaires/view/item/src/questionnaire_item_filler.dart
+++ b/lib/questionnaires/view/item/src/questionnaire_item_filler.dart
@@ -226,7 +226,7 @@ class QuestionnaireItemFillerTitle extends StatelessWidget {
               /// items with an index of 0 are skipped, as they usually
               /// represent basic information about the questionnaire
               ///
-              if (questionnaireTheme.showQuestionIndexOption() &&
+              if (questionnaireTheme.showAnswerIndexOption() &&
                   itemModel.isAnswerable)
                 HTML.toTextSpan(
                   context,

--- a/lib/questionnaires/view/item/src/questionnaire_item_filler.dart
+++ b/lib/questionnaires/view/item/src/questionnaire_item_filler.dart
@@ -213,6 +213,9 @@ class QuestionnaireItemFillerTitle extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final int questionNumber =
+        itemModel.questionnaireModel.getQuestionNumber(index);
+
     return Container(
         alignment: AlignmentDirectional.centerStart,
         padding: const EdgeInsets.only(top: 8.0),
@@ -222,12 +225,17 @@ class QuestionnaireItemFillerTitle extends StatelessWidget {
               /// Show question numbers (if flag set in the Questionnaire Theme)
               /// items with an index of 0 are skipped, as they usually
               /// represent basic information about the questionnaire
-              if (questionnaireTheme.showAnswerIndexOption() && index != 0)
-                WidgetSpan(
-                  alignment: PlaceholderAlignment.middle,
-                  // baseline: TextBaseline.alphabetic,
-                  child: Text('$index: ',
-                      style: Theme.of(context).textTheme.bodyText1),
+              ///
+              if (questionnaireTheme.showAnswerIndexOption() &&
+                  itemModel.isAnswerable)
+                HTML.toTextSpan(
+                  context,
+                  '$questionNumber: ',
+                  defaultTextStyle: Theme.of(context)
+                      .textTheme
+                      .bodyText1!
+                      // default to bold
+                      .apply(fontWeightDelta: 2),
                 ),
               if (leading != null) WidgetSpan(child: leading!),
               if (itemModel.titleText != null)

--- a/lib/questionnaires/view/item/src/questionnaire_item_filler.dart
+++ b/lib/questionnaires/view/item/src/questionnaire_item_filler.dart
@@ -2,7 +2,6 @@ import 'dart:convert';
 
 import 'package:fhir/r4.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/rendering.dart';
 import 'package:simple_html_css/simple_html_css.dart';
 
 import '../../../../fhir_types/fhir_types.dart';
@@ -12,17 +11,23 @@ import '../../../questionnaires.dart';
 class QuestionnaireItemFiller extends StatefulWidget {
   final QuestionnaireItemModel itemModel;
   final QuestionnaireFillerData questionnaireFiller;
+  final int index;
 
   factory QuestionnaireItemFiller.fromQuestionnaireFiller(
       QuestionnaireFillerData questionnaireFiller, int index,
       {Key? key}) {
-    return QuestionnaireItemFiller._(questionnaireFiller,
-        questionnaireFiller.questionnaireModel.itemModelAt(index),
+    return QuestionnaireItemFiller._(
+        questionnaireFiller: questionnaireFiller,
+        itemModel: questionnaireFiller.questionnaireModel.itemModelAt(index),
+        index: index,
         key: key);
   }
 
-  const QuestionnaireItemFiller._(this.questionnaireFiller, this.itemModel,
-      {Key? key})
+  const QuestionnaireItemFiller._(
+      {required this.questionnaireFiller,
+      required this.itemModel,
+      required this.index,
+      Key? key})
       : super(key: key);
 
   @override
@@ -34,6 +39,7 @@ class QuestionnaireItemFillerState extends State<QuestionnaireItemFiller> {
   late final Widget? _titleWidget;
   late final QuestionnaireResponseFiller _responseFiller;
   late final QuestionnaireFillerData _questionnaireFiller;
+  late final QuestionnaireTheme questionnaireTheme;
 
   late final FocusNode _focusNode;
 
@@ -44,8 +50,13 @@ class QuestionnaireItemFillerState extends State<QuestionnaireItemFiller> {
     super.initState();
     _focusNode = FocusNode(debugLabel: linkId, skipTraversal: true);
 
+    questionnaireTheme = widget.questionnaireFiller.questionnaireTheme;
+
     _titleWidget = QuestionnaireItemFillerTitle.fromQuestionnaireItemModel(
-        widget.itemModel);
+      itemModel: widget.itemModel,
+      questionnaireTheme: questionnaireTheme,
+      index: widget.index,
+    );
 
     _responseFiller = widget.questionnaireFiller.questionnaireTheme
         .createQuestionnaireResponseFiller(widget);
@@ -147,15 +158,25 @@ class QuestionnaireItemFillerTitle extends StatelessWidget {
   final QuestionnaireItemModel itemModel;
   final Widget? leading;
   final Widget? help;
+  final int index;
   final String htmlTitleText;
+  final QuestionnaireTheme questionnaireTheme;
 
-  const QuestionnaireItemFillerTitle._(
-      this.itemModel, this.htmlTitleText, this.leading, this.help,
-      {Key? key})
-      : super(key: key);
+  const QuestionnaireItemFillerTitle._({
+    required this.itemModel,
+    required this.questionnaireTheme,
+    required this.index,
+    required this.htmlTitleText,
+    this.leading,
+    this.help,
+    Key? key,
+  }) : super(key: key);
 
-  static Widget? fromQuestionnaireItemModel(QuestionnaireItemModel itemModel,
-      {Key? key}) {
+  static Widget? fromQuestionnaireItemModel(
+      {required QuestionnaireItemModel itemModel,
+      required QuestionnaireTheme questionnaireTheme,
+      required int index,
+      Key? key}) {
     if (itemModel.titleText == null) {
       return null;
     } else {
@@ -180,7 +201,12 @@ class QuestionnaireItemFillerTitle extends StatelessWidget {
           '$openStyleTag${htmlEscape.convert(itemModel.titleText!)}$closeStyleTag';
 
       return QuestionnaireItemFillerTitle._(
-          itemModel, htmlTitleText, leading, help,
+          itemModel: itemModel,
+          index: index,
+          questionnaireTheme: questionnaireTheme,
+          htmlTitleText: htmlTitleText,
+          leading: leading,
+          help: help,
           key: key);
     }
   }
@@ -193,6 +219,16 @@ class QuestionnaireItemFillerTitle extends StatelessWidget {
         child: Text.rich(
           TextSpan(
             children: <InlineSpan>[
+              /// Show question numbers (if flag set in the Questionnaire Theme)
+              /// items with an index of 0 are skipped, as they usually
+              /// represent basic information about the questionnaire
+              if (questionnaireTheme.showAnswerIndexOption() && index != 0)
+                WidgetSpan(
+                  alignment: PlaceholderAlignment.middle,
+                  // baseline: TextBaseline.alphabetic,
+                  child: Text('$index:  ',
+                      style: Theme.of(context).textTheme.headline6),
+                ),
               if (leading != null) WidgetSpan(child: leading!),
               if (itemModel.titleText != null)
                 HTML.toTextSpan(context, htmlTitleText,

--- a/lib/questionnaires/view/item/src/questionnaire_response_filler.dart
+++ b/lib/questionnaires/view/item/src/questionnaire_response_filler.dart
@@ -87,10 +87,12 @@ class QuestionnaireResponseFillerState
 
   @override
   Widget build(BuildContext context) {
+    final canSkipQuestions = questionnaireTheme.canSkipQuestions ?? false;
+
     // TODO(tiloc) show a list of answers, and buttons to add/remove if repeat
     return Column(mainAxisSize: MainAxisSize.min, children: [
       if (!responseModel.isAskedButDeclined) ..._answerFillers,
-      if (questionnaireTheme.showSkipOption() &&
+      if (canSkipQuestions &&
           !widget.itemModel.isReadOnly &&
           !widget.itemModel.isRequired)
         Row(children: [

--- a/lib/questionnaires/view/src/questionnaire_scroller.dart
+++ b/lib/questionnaires/view/src/questionnaire_scroller.dart
@@ -191,7 +191,7 @@ class _QuestionnaireScrollerState extends State<QuestionnaireScroller> {
                       ///
                       // itemScrollController: _listScrollController,
                       // itemPositionsListener: _itemPositionsListener,
-                      // minCacheExtent: 200, // Allow tabbing to prev/next items
+                      cacheExtent: 200, // Allow tabbing to prev/next items
 
                       itemCount: totalLength,
                       padding: const EdgeInsets.all(8),

--- a/lib/questionnaires/view/src/questionnaire_scroller.dart
+++ b/lib/questionnaires/view/src/questionnaire_scroller.dart
@@ -54,7 +54,6 @@ class QuestionnaireScroller extends StatefulWidget {
 class _QuestionnaireScrollerState extends State<QuestionnaireScroller> {
   QuestionnaireModel? _questionnaireModel;
   final ItemScrollController _listScrollController = ItemScrollController();
-  late final ScrollController _scrollController;
   final ItemPositionsListener _itemPositionsListener =
       ItemPositionsListener.create();
 
@@ -78,13 +77,11 @@ class _QuestionnaireScrollerState extends State<QuestionnaireScroller> {
   @override
   void initState() {
     super.initState();
-    _scrollController = ScrollController();
   }
 
   @override
   void dispose() {
     super.dispose();
-    _scrollController.dispose();
   }
 
   /// Scrolls to a position as conveyed by a [QuestionnaireErrorFlag].
@@ -155,8 +152,6 @@ class _QuestionnaireScrollerState extends State<QuestionnaireScroller> {
       builder: (BuildContext context) {
         _belowFillerContext = context;
         final questionnaireFiller = QuestionnaireFiller.of(context);
-        final bool showScrollbar = questionnaireFiller.questionnaireTheme
-            .showPersistentScrollbarOption();
 
         final mainMatterLength =
             questionnaireFiller.questionnaireItemModels.length;
@@ -176,79 +171,34 @@ class _QuestionnaireScrollerState extends State<QuestionnaireScroller> {
             setStateCallback: (fn) {
               setState(fn);
             },
-            child: showScrollbar
-                ? Scrollbar(
-                    controller: _scrollController,
-                    isAlwaysShown: true,
-                    child: ListView.builder(
-                      controller: _scrollController,
-
-                      /// These variables can't be used in a [ListView]
-                      /// And a Scrollbar cannot connect to an [itemScrollController]
-                      ///
-                      /// It may be better overall to separate these two methods
-                      /// so as to avoid having both controllers active in the same class
-                      ///
-                      // itemScrollController: _listScrollController,
-                      // itemPositionsListener: _itemPositionsListener,
-                      // minCacheExtent: 200, // Allow tabbing to prev/next items
-
-                      itemCount: totalLength,
-                      padding: const EdgeInsets.all(8),
-                      itemBuilder: (BuildContext context, int i) {
-                        final frontMatterIndex =
-                            (i < frontMatterLength) ? i : -1;
-                        final mainMatterIndex = (i >= frontMatterLength &&
-                                i < (frontMatterLength + mainMatterLength))
-                            ? (i - frontMatterLength)
-                            : -1;
-                        final backMatterIndex =
-                            (i >= (frontMatterLength + mainMatterLength) &&
-                                    i < totalLength)
-                                ? (i - (frontMatterLength + mainMatterLength))
-                                : -1;
-                        if (mainMatterIndex != -1) {
-                          return QuestionnaireFiller.of(context)
-                              .itemFillerAt(mainMatterIndex);
-                        } else if (backMatterIndex != -1) {
-                          return widget.backMatter![backMatterIndex];
-                        } else if (frontMatterIndex != -1) {
-                          return widget.frontMatter![frontMatterIndex];
-                        } else {
-                          throw StateError('ListView index out of bounds: $i');
-                        }
-                      },
-                    ),
-                  )
-                : ScrollablePositionedList.builder(
-                    itemScrollController: _listScrollController,
-                    itemPositionsListener: _itemPositionsListener,
-                    itemCount: totalLength,
-                    padding: const EdgeInsets.all(8),
-                    minCacheExtent: 200, // Allow tabbing to prev/next items
-                    itemBuilder: (BuildContext context, int i) {
-                      final frontMatterIndex = (i < frontMatterLength) ? i : -1;
-                      final mainMatterIndex = (i >= frontMatterLength &&
-                              i < (frontMatterLength + mainMatterLength))
-                          ? (i - frontMatterLength)
+            child: ScrollablePositionedList.builder(
+                itemScrollController: _listScrollController,
+                itemPositionsListener: _itemPositionsListener,
+                itemCount: totalLength,
+                padding: const EdgeInsets.all(8),
+                minCacheExtent: 200, // Allow tabbing to prev/next items
+                itemBuilder: (BuildContext context, int i) {
+                  final frontMatterIndex = (i < frontMatterLength) ? i : -1;
+                  final mainMatterIndex = (i >= frontMatterLength &&
+                          i < (frontMatterLength + mainMatterLength))
+                      ? (i - frontMatterLength)
+                      : -1;
+                  final backMatterIndex =
+                      (i >= (frontMatterLength + mainMatterLength) &&
+                              i < totalLength)
+                          ? (i - (frontMatterLength + mainMatterLength))
                           : -1;
-                      final backMatterIndex =
-                          (i >= (frontMatterLength + mainMatterLength) &&
-                                  i < totalLength)
-                              ? (i - (frontMatterLength + mainMatterLength))
-                              : -1;
-                      if (mainMatterIndex != -1) {
-                        return QuestionnaireFiller.of(context)
-                            .itemFillerAt(mainMatterIndex);
-                      } else if (backMatterIndex != -1) {
-                        return widget.backMatter![backMatterIndex];
-                      } else if (frontMatterIndex != -1) {
-                        return widget.frontMatter![frontMatterIndex];
-                      } else {
-                        throw StateError('ListView index out of bounds: $i');
-                      }
-                    },
-                  ),
+                  if (mainMatterIndex != -1) {
+                    return QuestionnaireFiller.of(context)
+                        .itemFillerAt(mainMatterIndex);
+                  } else if (backMatterIndex != -1) {
+                    return widget.backMatter![backMatterIndex];
+                  } else if (frontMatterIndex != -1) {
+                    return widget.frontMatter![frontMatterIndex];
+                  } else {
+                    throw StateError('ListView index out of bounds: $i');
+                  }
+                }),
           ),
         );
       },

--- a/lib/questionnaires/view/src/questionnaire_scroller.dart
+++ b/lib/questionnaires/view/src/questionnaire_scroller.dart
@@ -191,7 +191,7 @@ class _QuestionnaireScrollerState extends State<QuestionnaireScroller> {
                       ///
                       // itemScrollController: _listScrollController,
                       // itemPositionsListener: _itemPositionsListener,
-                      cacheExtent: 200, // Allow tabbing to prev/next items
+                      // minCacheExtent: 200, // Allow tabbing to prev/next items
 
                       itemCount: totalLength,
                       padding: const EdgeInsets.all(8),

--- a/lib/questionnaires/view/src/questionnaire_theme.dart
+++ b/lib/questionnaires/view/src/questionnaire_theme.dart
@@ -36,10 +36,6 @@ abstract class QuestionnaireTheme {
 
   /// Returns whether each question will be preceded by its own ID.
   bool showQuestionIndexOption();
-
-  /// Replace default 'scrollable positioned list' with something that allows
-  /// the user to persistently see a scrollbar on the trailing edge
-  bool showPersistentScrollbarOption();
 }
 
 /// The Faiadashu default implementation of [QuestionnaireTheme].
@@ -56,13 +52,11 @@ class FDashQuestionnaireTheme implements QuestionnaireTheme {
   final bool? canSkipQuestions;
   final bool? showNullAnswerChoices;
   final bool? showQuestionNumbers;
-  final bool? showPersistentScrollbar;
 
   const FDashQuestionnaireTheme(
       {this.canSkipQuestions,
       this.showNullAnswerChoices,
-      this.showQuestionNumbers,
-      this.showPersistentScrollbar});
+      this.showQuestionNumbers});
 
   @override
   QuestionnaireItemFiller createQuestionnaireItemFiller(
@@ -132,7 +126,4 @@ class FDashQuestionnaireTheme implements QuestionnaireTheme {
 
   @override
   bool showQuestionIndexOption() => showQuestionNumbers ?? false;
-
-  @override
-  bool showPersistentScrollbarOption() => showPersistentScrollbar ?? false;
 }

--- a/lib/questionnaires/view/src/questionnaire_theme.dart
+++ b/lib/questionnaires/view/src/questionnaire_theme.dart
@@ -36,6 +36,10 @@ abstract class QuestionnaireTheme {
 
   /// Returns whether each question will be preceded by its own ID.
   bool showQuestionIndexOption();
+
+  /// Replace default 'scrollable positioned list' with something that allows
+  /// the user to persistently see a scrollbar on the trailing edge
+  bool showPersistentScrollbarOption();
 }
 
 /// The Faiadashu default implementation of [QuestionnaireTheme].
@@ -52,11 +56,13 @@ class FDashQuestionnaireTheme implements QuestionnaireTheme {
   final bool? canSkipQuestions;
   final bool? showNullAnswerChoices;
   final bool? showQuestionNumbers;
+  final bool? showPersistentScrollbar;
 
   const FDashQuestionnaireTheme(
       {this.canSkipQuestions,
       this.showNullAnswerChoices,
-      this.showQuestionNumbers});
+      this.showQuestionNumbers,
+      this.showPersistentScrollbar});
 
   @override
   QuestionnaireItemFiller createQuestionnaireItemFiller(
@@ -126,4 +132,7 @@ class FDashQuestionnaireTheme implements QuestionnaireTheme {
 
   @override
   bool showQuestionIndexOption() => showQuestionNumbers ?? false;
+
+  @override
+  bool showPersistentScrollbarOption() => showPersistentScrollbar ?? false;
 }

--- a/lib/questionnaires/view/src/questionnaire_theme.dart
+++ b/lib/questionnaires/view/src/questionnaire_theme.dart
@@ -35,7 +35,7 @@ abstract class QuestionnaireTheme {
   bool showNullCodingOption();
 
   /// Returns whether each question will be preceded by its own ID.
-  bool showAnswerIndexOption();
+  bool showQuestionIndexOption();
 }
 
 /// The Faiadashu default implementation of [QuestionnaireTheme].
@@ -51,12 +51,12 @@ class FDashQuestionnaireTheme implements QuestionnaireTheme {
 
   final bool? canSkipQuestions;
   final bool? showNullAnswerChoices;
-  final bool? showAnswerIndexes;
+  final bool? showQuestionNumbers;
 
   const FDashQuestionnaireTheme(
       {this.canSkipQuestions,
       this.showNullAnswerChoices,
-      this.showAnswerIndexes});
+      this.showQuestionNumbers});
 
   @override
   QuestionnaireItemFiller createQuestionnaireItemFiller(
@@ -125,5 +125,5 @@ class FDashQuestionnaireTheme implements QuestionnaireTheme {
   bool showNullCodingOption() => showNullAnswerChoices ?? true;
 
   @override
-  bool showAnswerIndexOption() => showAnswerIndexes ?? false;
+  bool showQuestionIndexOption() => showQuestionNumbers ?? false;
 }

--- a/lib/questionnaires/view/src/questionnaire_theme.dart
+++ b/lib/questionnaires/view/src/questionnaire_theme.dart
@@ -33,6 +33,9 @@ abstract class QuestionnaireTheme {
 
   /// Returns whether user will be offered option for a null radio button value.
   bool showNullCodingOption();
+
+  /// Returns whether each question will be preceded by its own ID.
+  bool showAnswerIndexOption();
 }
 
 /// The Faiadashu default implementation of [QuestionnaireTheme].
@@ -48,9 +51,12 @@ class FDashQuestionnaireTheme implements QuestionnaireTheme {
 
   final bool? canSkipQuestions;
   final bool? showNullAnswerChoices;
+  final bool? showAnswerIndexes;
 
   const FDashQuestionnaireTheme(
-      {this.canSkipQuestions, this.showNullAnswerChoices});
+      {this.canSkipQuestions,
+      this.showNullAnswerChoices,
+      this.showAnswerIndexes});
 
   @override
   QuestionnaireItemFiller createQuestionnaireItemFiller(
@@ -117,4 +123,7 @@ class FDashQuestionnaireTheme implements QuestionnaireTheme {
 
   @override
   bool showNullCodingOption() => showNullAnswerChoices ?? true;
+
+  @override
+  bool showAnswerIndexOption() => showAnswerIndexes ?? false;
 }

--- a/lib/questionnaires/view/src/questionnaire_theme.dart
+++ b/lib/questionnaires/view/src/questionnaire_theme.dart
@@ -5,6 +5,11 @@ import '../../questionnaires.dart';
 
 /// Create the views for all levels of a questionnaire. Provide styling theme.
 abstract class QuestionnaireTheme {
+  const QuestionnaireTheme(
+      {this.canSkipQuestions,
+      this.showNullAnswerChoices,
+      this.showQuestionNumbers});
+
   /// Returns a [QuestionnaireItemFiller] for a given [QuestionnaireFiller].
   ///
   /// Used by [QuestionnaireFiller].
@@ -29,17 +34,22 @@ abstract class QuestionnaireTheme {
   InputDecoration createDecoration();
 
   /// Returns whether user will be offered option to skip question.
-  bool showSkipOption();
+  final bool? canSkipQuestions;
 
   /// Returns whether user will be offered option for a null radio button value.
-  bool showNullCodingOption();
+  final bool? showNullAnswerChoices;
 
   /// Returns whether each question will be preceded by its own ID.
-  bool showQuestionIndexOption();
+  final bool? showQuestionNumbers;
 }
 
 /// The Faiadashu default implementation of [QuestionnaireTheme].
 class FDashQuestionnaireTheme implements QuestionnaireTheme {
+  const FDashQuestionnaireTheme(
+      {this.canSkipQuestions,
+      this.showNullAnswerChoices,
+      this.showQuestionNumbers});
+
   static final _logger = Logger(FDashQuestionnaireTheme);
 
   /// These options may be set to customize the Faiadashu default theme
@@ -48,15 +58,16 @@ class FDashQuestionnaireTheme implements QuestionnaireTheme {
   /// within [QuestionnaireScroller], [QuestionnaireScrollerPage],
   /// [QuestionnaireStepper], or [QuestionnaireStepperPage]
   /// and set the options you want
+  ///
 
+  @override
   final bool? canSkipQuestions;
-  final bool? showNullAnswerChoices;
-  final bool? showQuestionNumbers;
 
-  const FDashQuestionnaireTheme(
-      {this.canSkipQuestions,
-      this.showNullAnswerChoices,
-      this.showQuestionNumbers});
+  @override
+  final bool? showNullAnswerChoices;
+
+  @override
+  final bool? showQuestionNumbers;
 
   @override
   QuestionnaireItemFiller createQuestionnaireItemFiller(
@@ -117,13 +128,4 @@ class FDashQuestionnaireTheme implements QuestionnaireTheme {
   InputDecoration createDecoration() {
     return const InputDecoration(filled: true);
   }
-
-  @override
-  bool showSkipOption() => canSkipQuestions ?? false;
-
-  @override
-  bool showNullCodingOption() => showNullAnswerChoices ?? true;
-
-  @override
-  bool showQuestionIndexOption() => showQuestionNumbers ?? false;
 }


### PR DESCRIPTION
### Feature 1 -  Show Question Numbers
You can now set a custom flag within the `QuestionnaireTheme` class to show automatically-generated numbers for each question present within the survey. This flag has been tentatively named `showQuestionNumbers` and specifically works for all questions that have the `isAnswerable` boolean set as true.

Use of this package is similar to other QuestionnaireTheme options, such as:

```dart
QuestionnaireScroller(
      fhirResourceProvider: controller.registryFhirResourceProvider,
      scaffoldBuilder: const SurveyScaffold(),
      questionnaireTheme: const FDashQuestionnaireTheme(
        canSkipQuestions: true,
        showNullAnswerChoices: false,
        showQuestionNumbers: true,
      ),
    );
```

_NOTE: Feature 2 was removed from this PR. It will need to be further tested prior to submission_

~~### Feature 2 -  Show Persistent Scrollbar~~
~~Currently, the default `ScrollablePositionedList` is unable to show how much data remain in the questionnaire when scrolling vertically. An optional flag was added to transition this list back into a `ListView`, wrapped with a `Scrollbar` that is persistently shown.~~